### PR TITLE
Dev files

### DIFF
--- a/src/const/constants.lsp
+++ b/src/const/constants.lsp
@@ -1,8 +1,19 @@
+;; PATHS
+(defconstant +maze-path+ "../data/mazes/")
+
 ;; CELL TYPES
 (defconstant +cell-type-entrance+ "entrance")
 (defconstant +cell-type-exit+ "exit")
 (defconstant +cell-type-path+ "path")
 (defconstant +cell-type-wall+ "wall")
+
+;; CHAR REPRESENTATION TYPES
+(defconstant +char-entrance+  #\e)
+(defconstant +char-exit+  #\s)
+(defconstant +char-path+  #\.)
+(defconstant +char-wall+  #\#)
+(defconstant +char-space+  #\Space)
+(defconstant +char-newline+  #\Newline)
 
 ;; Cell "object": 
 ;;(

--- a/src/core/cell.lsp
+++ b/src/core/cell.lsp
@@ -1,3 +1,36 @@
+;; Definition: Given a cell, returns the encrypted character
+;; In:
+;;    - cell: Cell "object"
+;; Out: Char encoding the cell
+(defun char-from-cell (cell)
+  (cond
+    ((eq (car cell) +cell-type-wall+) +char-wall+)
+    ((eq (car cell) +cell-type-path+) +char-path+)
+    ((eq (car cell) +cell-type-entrance+) +char-entrance+)
+    ((eq (car cell) +cell-type-exit+) +char-exit+)
+    (t +char-space+)
+  )
+)
+
+;; Definition: Given a cell encrypted char representing a cell
+;; In:
+;;    - c: Encrypted char
+;; Out: New cell "object"
+(defun cell-from-char (c)
+  (list
+    (cond 
+      ((char= c +char-wall+) +cell-type-wall+)
+      ((char= c +char-path+) +cell-type-path+)
+      ((char= c +char-entrance+) +cell-type-entrance+)
+      ((char= c +char-exit+) +cell-type-exit+)
+      (t +cell-type-path+) ; Path as default
+    ); type
+    nil                           ; visible
+    (char= c +char-entrance+)     ; current
+    nil
+  ) 
+)
+
 ;; Definition: Returns a new cell changing the type of the given
 ;; In:
 ;;    - cell = The base cell to copy

--- a/src/core/file.lsp
+++ b/src/core/file.lsp
@@ -1,0 +1,53 @@
+;; Function: write
+;; Description: Writes content to the specified file. If the file does not exist, it is created.
+;;              Content is written character by character.
+;; In:
+;;   - name: String. Name (or path) of the file to write to.
+;;   - content: List of characters to write into the file.
+;; Out: None
+(defun write (name content)
+  (let ((fp (open (concatenate 'string +maze-path+ name) :direction :output
+                       :if-exists :supersede
+                       :if-does-not-exist :create)))
+       (write-aux fp content)
+       (close fp)
+  )
+)
+
+;; Function: write-aux
+;; Description: Helper function for 'write'. Writes a list of characters to an open file stream.
+;; In:
+;;   - fp: Output file stream.
+;;   - content: List of characters to write.
+;; Out: None
+(defun write-aux (fp content)
+  (cond
+    ((null content) nil)
+    (t (write-char (car content) fp)
+       (write-aux fp (cdr content)))
+  )
+)
+
+;; Description: Reads content from the specified file character by character and returns it as a list.
+;; In:
+;;   - name: String. Name (or path) of the file to read.
+;; Out: List of characters read from the file.
+(defun read (name)
+  (let* ((fp (open (concatenate 'string +maze-path+ name) :direction :input))
+         (content (read-aux fp)))
+        (close fp)
+        content)
+)
+
+;; Function: read-aux
+;; Description: Helper function for 'read'. Reads all characters from an open file stream and 
+;;              returns them as a list.
+;; In:
+;;   - fp: Input file stream.
+;; Out: List of characters read.
+(defun read-aux (fp)
+  (let ((c (read-char fp nil nil)))
+       (cond ((null c) '())
+             (t (cons c (read-aux fp))))
+  )
+)

--- a/src/main.lsp
+++ b/src/main.lsp
@@ -2,6 +2,7 @@
 (load "./const/constants.lsp")
 
 ;; CORE
+(load "./core/file.lsp")
 (load "./core/utils.lsp")
 (load "./core/cell.lsp")
 

--- a/src/maze/generate.lsp
+++ b/src/maze/generate.lsp
@@ -212,3 +212,7 @@
     (generate-path maze n m)
   )
 )
+
+(defun create-maze (name n m)
+  (write name (encrypt-maze (generate n m)))
+)

--- a/src/maze/maze.lsp
+++ b/src/maze/maze.lsp
@@ -107,49 +107,34 @@
   )
 )
 
-;; Definition: Returns the character representation of a cell type.
-;; In:
-;;   - cell: A cell object (a list whose car is the cell type)
-;; Out: A string character representing the cell
-(defun cell-char (cell)
-  (cond
-    ((eq (car cell) +cell-type-wall+) #\#)
-    ((eq (car cell) +cell-type-path+) #\.)
-    ((eq (car cell) +cell-type-entrance+) #\e)
-    ((eq (car cell) +cell-type-exit+) #\s)
-    (t #\Space)
-  )
-)
-
-
-;; Definition: Recursively processes one row of the grid, concatenating cell chars.
+;; Definition: Recursively encrypts one row of the grid, concatenating cell chars.
 ;; In:
 ;;   - grid: The maze grid (list of rows)
 ;;   - row: The index of the current row
-;;   - col: The current column index being processed
+;;   - col: The current column index being encrypted
 ;;   - cols: Total number of columns
-;; Out: A string representing the processed row from col to end
-(defun process-col (grid row col cols)
+;; Out: A string representing the encrypted row from col to end
+(defun encrypt-col (grid row col cols)
   (cond
     ((>= col cols) nil)
-    (t (cons (cell-char (get-cell grid row col))
-             (process-col grid row (+ col 1) cols)))
+    (t (cons (char-from-cell (get-cell grid row col))
+             (encrypt-col grid row (+ col 1) cols)))
   )
 )
 
-;; Definition: Recursively processes all rows of the grid, concatenating lines.
+;; Definition: Recursively encrypts all rows of the grid, concatenating lines.
 ;; In:
 ;;   - grid: The maze grid (list of rows)
-;;   - row: The current row index being processed
+;;   - row: The current row index being encrypted
 ;;   - rows: Total number of rows
 ;;   - cols: Total number of columns
 ;; Out: A string representing the entire maze formatted
-(defun process-row (grid row rows cols)
+(defun encrypt-row (grid row rows cols)
   (cond
     ((>= row rows) nil)
-    (t (append (process-col grid row 0 cols)
+    (t (append (encrypt-col grid row 0 cols)
                (list #\Newline)
-               (process-row grid (+ row 1) rows cols)))
+               (encrypt-row grid (+ row 1) rows cols)))
   )
 )
 
@@ -166,6 +151,54 @@
   (let* ((grid (get-grid maze))
          (rows (length grid))
          (cols (length (car grid))))
-        (process-row grid 0 rows cols)
+        (encrypt-row grid 0 rows cols)
   )
+)
+
+;; Definition: Given a row of encrypted cells, returns a row with the cell "objects"
+;; In:
+;;   - row: A list of chars encrypted.
+;; Out: A list of cell "objects"
+(defun decrypt-row (row)
+  (cond 
+    ((null row) nil)
+    (t (cons (cell-from-char (car row)) (decrypt-row (cdr row))))
+  )
+)
+
+;; Definition: Given a list, splits it by rows separated by #\Newline
+;; In:
+;;   - chars: The initial list of characters
+;; Out: List of lists of chars, separated by the splitter #\Newline
+(defun split-by-newline (chars)
+  (reduce (lambda (acc ch)
+            (cond
+              ((char= ch #\Newline) (append acc (list '())))
+              (t (let ((last-row (car (last acc))))
+                 (append (butlast acc)
+                         (list (append last-row (list ch))))))
+            )
+          )
+          chars
+          :initial-value (list '()))
+)
+
+;; Definition: Given a list of encrypted cells, returns a grid for a maze decrypted.
+;; In:
+;;   - grid: The list of characters
+;; Out: A grid of cell "objects"
+(defun decrypt-grid (grid)
+  (mapcar #'decrypt-row (split-by-newline grid))
+)
+
+;; Definition: Given a list of encrypted cells, returns a the maze decrypted.
+;; In:
+;;   - chars: The list of characters
+;; Out: The maze "object"
+(defun decrypt-maze (chars)
+  (init-current (list (decrypt-grid chars) 0 0))
+)
+
+(defun load-maze (name)
+  (decrypt-maze (read name))
 )

--- a/src/maze/maze.lsp
+++ b/src/maze/maze.lsp
@@ -107,3 +107,65 @@
   )
 )
 
+;; Definition: Returns the character representation of a cell type.
+;; In:
+;;   - cell: A cell object (a list whose car is the cell type)
+;; Out: A string character representing the cell
+(defun cell-char (cell)
+  (cond
+    ((eq (car cell) +cell-type-wall+) #\#)
+    ((eq (car cell) +cell-type-path+) #\.)
+    ((eq (car cell) +cell-type-entrance+) #\e)
+    ((eq (car cell) +cell-type-exit+) #\s)
+    (t #\Space)
+  )
+)
+
+
+;; Definition: Recursively processes one row of the grid, concatenating cell chars.
+;; In:
+;;   - grid: The maze grid (list of rows)
+;;   - row: The index of the current row
+;;   - col: The current column index being processed
+;;   - cols: Total number of columns
+;; Out: A string representing the processed row from col to end
+(defun process-col (grid row col cols)
+  (cond
+    ((>= col cols) nil)
+    (t (cons (cell-char (get-cell grid row col))
+             (process-col grid row (+ col 1) cols)))
+  )
+)
+
+;; Definition: Recursively processes all rows of the grid, concatenating lines.
+;; In:
+;;   - grid: The maze grid (list of rows)
+;;   - row: The current row index being processed
+;;   - rows: Total number of rows
+;;   - cols: Total number of columns
+;; Out: A string representing the entire maze formatted
+(defun process-row (grid row rows cols)
+  (cond
+    ((>= row rows) nil)
+    (t (append (process-col grid row 0 cols)
+               (list #\Newline)
+               (process-row grid (+ row 1) rows cols)))
+  )
+)
+
+;; Definition: Encrypts the given maze into format:
+;;   - # for walls
+;;   - . for paths
+;;   - e for entrance
+;;   - s for exit
+;;   - \n at the end of each row
+;; In:
+;;   - maze: The maze object
+;; Out: Formatted string encrypting maze
+(defun encrypt-maze (maze)
+  (let* ((grid (get-grid maze))
+         (rows (length grid))
+         (cols (length (car grid))))
+        (process-row grid 0 rows cols)
+  )
+)


### PR DESCRIPTION
This pull request introduces functionality to encrypt and decrypt mazes, along with file I/O operations to save and load mazes. The changes include defining constants for character encodings, implementing helper functions for encryption and decryption, adding file operations for reading and writing maze data, and integrating these functionalities into the maze generation process.

### Maze Encryption and Decryption:
* Added constants in `src/const/constants.lsp` to define character representations for maze elements (e.g., walls, paths, entrance, exit) (`[src/const/constants.lspR1-R17](diffhunk://#diff-3de41924931b23d1c4f7747d9ce5be7df851fbe3d9111a65e56fa8a6972ce8f9R1-R17)`).
* Implemented `char-from-cell` and `cell-from-char` in `src/core/cell.lsp` to convert between cell objects and their character encodings (`[src/core/cell.lspR1-R33](diffhunk://#diff-76c9eade5bdec3a81bb1f52b07296e9583220eb8fc4aff9287623f6b5f4b7bb5R1-R33)`).
* Added functions in `src/maze/maze.lsp` for encrypting (`encrypt-maze`, `encrypt-row`, `encrypt-col`) and decrypting (`decrypt-maze`, `decrypt-grid`, `decrypt-row`, `split-by-newline`) maze data (`[src/maze/maze.lspR110-R204](diffhunk://#diff-744510616bb711e998bf88e6e49aae8b7473e4e1e952720b0f3012a9ef2fd05bR110-R204)`).

### File I/O Operations:
* Introduced `write` and `read` functions in `src/core/file.lsp` to handle file operations for saving and loading maze data, along with helper functions `write-aux` and `read-aux` (`[src/core/file.lspR1-R53](diffhunk://#diff-36dc94e08501dccf2ffe0b043b156090ea93cc7c6d3d4ba3ea34f3f439f0fc65R1-R53)`).

### Integration with Maze Generation:
* Added a `create-maze` function in `src/maze/generate.lsp` to generate, encrypt, and save a maze to a file (`[src/maze/generate.lspR215-R218](diffhunk://#diff-57a5708d6f6afff84b351415dbb7359ef267bff60eb443e6de291eefa1fed50cR215-R218)`).
* Updated `src/main.lsp` to load the new `file.lsp` module (`[src/main.lspR5](diffhunk://#diff-2b7455382642409e39d19469b81526ff9833a4494a8f24d8e047944054f4d069R5)`).