### PR TITLE
Dev graphics

### DIFF
--- a/src/const/constants.lsp
+++ b/src/const/constants.lsp
@@ -16,8 +16,18 @@
 (defconstant +char-newline+  #\Newline)
 
 ;; DIMENSION LIMITS
-(defconstant +min-dimension+ 10) ; This will be used as viewport dimension, so less makes no sense
+(defconstant +min-dimension+ 10) ; This will be used as viewport dimension, so less than 10 makes no sense
 (defconstant +max-dimension+ 50) ; Increase this causes stack overflow on squared mazes (50x50)
+
+;; GRAPHICS CONSTANTS
+(defconstant +screen-height+ 375)
+(defconstant +screen-width+ 640)
+(defconstant +viewport-size+ 10)
+(defconstant +wall-color+ '(0 0 0))
+(defconstant +path-color+ '(255 255 255))
+(defconstant +entrance-color+ '(255 95 60))
+(defconstant +exit-color+ '(60 255 70))
+(defconstant +player-color+ '(60 100 255))
 
 ;; Cell "object": 
 ;;(

--- a/src/core/cell.lsp
+++ b/src/core/cell.lsp
@@ -31,6 +31,21 @@
   ) 
 )
 
+;; Definition: Given a cell cell, returns the color to paint it
+;; In:
+;;    - cell: The cell to check correspondant color
+;; Out: The color to be painted format rgb
+(defun get-cell-color (cell)
+  (cond 
+    ((string= (caddr cell) t) +player-color+)
+    ((string= (car cell) +cell-type-path+) +path-color+)
+    ((string= (car cell) +cell-type-wall+) +wall-color+)
+    ((string= (car cell) +cell-type-entrance+) +entrance-color+)
+    ((string= (car cell) +cell-type-exit+) +exit-color+)
+    (t +path-color+)
+  )
+)
+
 ;; Definition: Returns a new cell changing the type of the given
 ;; In:
 ;;    - cell = The base cell to copy

--- a/src/graphics/graphics.lsp
+++ b/src/graphics/graphics.lsp
@@ -1,0 +1,90 @@
+;; Definition: Sets paint color to the given in rgb list format
+;; In:
+;;   - rgb: The color to set
+;; Out: None
+(defun set-color (rgb)
+  (apply #'color rgb))
+
+;; Definition: Paints a square of the color given
+;; In:
+;;   - size: The size of the square in px
+;;   - color: The color of the square in rgb list format
+;; Out: None
+(defun square (size color)
+  (cond
+      ((= size 0) nil)
+      (t  (set-color color)
+          (drawrel 0 (- size))        ; move down
+          (drawrel size 0)            ; move right
+          (drawrel 0 size)            ; move up
+          (drawrel (- size) 0)        ; move left
+          (square (- size 1) color))))
+
+;; Definition: Paints a cell given the size to paint it and the cell
+;; In:
+;;   - size: Size in px
+;;   - cell: The cell to be painted
+;; Out: None
+(defun draw-cell (size cell)
+  (square size (get-cell-color cell)))
+
+;; Definition: Paints a row of cells given, with the specified cell-size
+;; In:
+;;   - size: Cell size in px
+;;   - row: Row of cells
+;; Out: None
+(defun draw-row (size row)
+  (cond
+    ((null row) nil)
+    (t
+      (draw-cell size (car row))
+      (moverel size 0)
+      (draw-row size (cdr row))
+      (moverel (- size) 0))))
+
+;; Definition: Paints a grid of cells given, with the specified cell-size
+;; In:
+;;   - size: Cell size in px
+;;   - grid: Grid of cells
+;; Out: None
+(defun draw-grid (size grid)
+  (cond
+    ((null grid) nil)
+    (t
+      (draw-row size (car grid))
+      (moverel 0 (- size))
+      (draw-grid size (cdr grid)))))
+
+;; Definition: Paints a maze given, viewport or minimap
+;; In:
+;;   - maze: The maze to paint
+;; Out: None
+(defun draw-maze (maze)
+  (cond
+    ((get-minimap maze)
+      (let* ((grid (get-grid maze))
+              (rows (length grid))
+              (cols (length (car grid)))
+              (longest (max rows cols))
+              (margin (+ 1 (floor (/ (mod +screen-height+ longest)) 2)))
+              (cell-size (floor (/ (- +screen-height+ (* 2 margin)) longest)))
+              (v-margin (floor ( / (- +screen-height+ (* rows cell-size)) 2)))
+              (h-margin (floor ( / (- +screen-height+ (* cols cell-size)) 2))))
+        (move h-margin (- +screen-height+ v-margin))
+        (draw-grid 
+          (floor (/ 
+                    (- +screen-height+ (* 2 margin))
+                    (max rows cols)))
+          grid)))
+    (t
+      (let* ((margin (+ 1 (floor (/ (mod +screen-height+ (+ 1 +viewport-size+)) 2)))))
+        (move margin (- +screen-height+ margin))
+        (draw-grid
+              (floor (/ (min +screen-height+ +screen-width+) (+ 1 +viewport-size+))) ; +1 is to countwith player position
+              (get-viewport maze))))))
+
+(defmacro test (file)
+  `(progn
+     (cls)
+     (draw-maze (set-minimap (set-current (load-maze ,file) 5 6) t) )
+     (values)))  ; evita impresión

--- a/src/main.lsp
+++ b/src/main.lsp
@@ -9,3 +9,6 @@
 ;; MAZE
 (load "./maze/maze.lsp")
 (load "./maze/generate.lsp")
+
+;; GRAPHICS
+(load "./graphics/graphics.lsp")

--- a/src/maze/maze.lsp
+++ b/src/maze/maze.lsp
@@ -4,10 +4,11 @@
 ;;   grid: A 2D list of cell objects (the maze grid),
 ;;   current-row: Row of the current/active cell
 ;;   current-col: Column of the current/active cell
+;;   minimap: Boolean flag that indicates wether minimap is on/off
 ;; )
 
 ;; Definition: A default maze with no grid and no current cell set.
-(defconstant +default-maze+ (list nil nil))
+(defconstant +default-maze+ (list 0 0 nil))
 
 ;; Definition: Returns the grid (2D list of cells) from the maze.
 ;; In:
@@ -23,7 +24,7 @@
 ;;   - new-grid: The new 2D list of cells to set as the grid
 ;; Out: A new maze object with the grid updated
 (defun set-grid (maze new-grid)
-  (list new-grid (get-current maze))
+  (list new-grid (get-current maze) (get-minimap maze))
 )
 
 ;; Definition: Returns the position of the current active cell in the maze.
@@ -37,12 +38,26 @@
 ;; Definition: Sets the current cell position in the maze.
 ;; In:
 ;;   - maze: The maze object
-;;   - current-row: Row of the current/active cell
-;;   - current-col: Column of the current/active cell
+;;   - new-row: Row of the current/active cell
+;;   - new-col: Column of the current/active cell
 ;; Out: A new maze object with the current cell updated
-(defun set-current (maze row col)
-  (list (get-grid maze) row col)
-)
+(defun set-current (maze new-row new-col)
+  (let* ((grid (get-grid maze))
+         (old-row (get-current-row maze))
+         (old-col (get-current-col maze))
+         
+         ;; Get and update the old current cell (set current to NIL)
+         (old-cell (get-cell grid old-row old-col))
+         (updated-old-cell (change-cell-current old-cell nil))
+         (grid-with-old-cleared (replace-in-grid grid old-row old-col updated-old-cell))
+         
+         ;; Get and update the new current cell (set current to T)
+         (new-cell (get-cell grid-with-old-cleared new-row new-col))
+         (updated-new-cell (change-cell-current new-cell t))
+         (final-grid (replace-in-grid grid-with-old-cleared new-row new-col updated-new-cell)))
+    
+    ;; Return the updated maze as a list (or a struct if you use one)
+    (list final-grid new-row new-col (get-minimap maze))))
 
 ;; Definition: Returns the row index of the current active cell in the maze.
 ;; In:
@@ -58,6 +73,27 @@
 ;; Out: An integer representing the current cell's column
 (defun get-current-col (maze)
   (caddr maze)
+)
+
+;; Definition: Returns wether the minimap is active or not
+;; In:
+;;    - maze = The maze object
+;; Out: A boolean for minimap state
+(defun get-minimap (maze)
+  (cadddr maze)
+)
+
+;; Definition: Sets wether the minimap is open or not
+;; In:
+;;    - maze: The maze object
+;;    - minimap: The new minimap state 
+;; Out: The maze "object" updating minimap state
+(defun set-minimap (maze minimap)
+  (list
+    (get-grid maze)
+    (get-current maze)
+    minimap
+  )
 )
 
 ;; Definition: Finds the position of the first cell of a given type in the grid.


### PR DESCRIPTION
This pull request introduces significant enhancements to the maze rendering system by adding graphical capabilities, supporting viewport and minimap rendering, and improving the maze data structure to handle these features. The most important changes include defining constants for graphical rendering, implementing functions for drawing cells and grids, adding viewport and minimap functionality, and updating the maze structure to accommodate these features.

### Graphics Enhancements:
* Added new graphical constants in `src/const/constants.lsp` for screen dimensions, viewport size, and colors for various maze elements like walls, paths, entrances, exits, and the player.
* Implemented functions in `src/graphics/graphics.lsp` for rendering cells, rows, grids, and the entire maze, including viewport and minimap support.

### Maze Structure Updates:
* Updated the maze data structure in `src/maze/maze.lsp` to include a `minimap` flag for toggling minimap visibility.
* Modified functions in `src/maze/maze.lsp` to handle the new `minimap` flag and ensure proper updates to the maze structure, including the current cell's state. [[1]](diffhunk://#diff-744510616bb711e998bf88e6e49aae8b7473e4e1e952720b0f3012a9ef2fd05bL26-R27) [[2]](diffhunk://#diff-744510616bb711e998bf88e6e49aae8b7473e4e1e952720b0f3012a9ef2fd05bL40-R60) [[3]](diffhunk://#diff-744510616bb711e998bf88e6e49aae8b7473e4e1e952720b0f3012a9ef2fd05bR78-R98)

### Viewport Functionality:
* Added functions in `src/maze/maze.lsp` to compute and retrieve the viewport grid based on the player's position and the `+viewport-size+` constant.

### Integration:
* Integrated the graphics module by loading `src/graphics/graphics.lsp` in the main file `src/main.lsp`.