### PR TITLE
Visualize "trail" for player visited cells

### DIFF
--- a/src/const/constants.lsp
+++ b/src/const/constants.lsp
@@ -34,6 +34,7 @@
 (defconstant +entrance-color+ '(255 95 60))
 (defconstant +exit-color+ '(60 255 70))
 (defconstant +player-color+ '(60 100 255))
+(defconstant +visited-color+ '(255 255 60))
 
 ;; GAME CONSTANTS
 (defconstant up-keys    '(119 87))  ; w / W

--- a/src/core/cell.lsp
+++ b/src/core/cell.lsp
@@ -33,10 +33,11 @@
 (defun get-cell-color (cell)
   (cond 
     ((string= (caddr cell) t) +player-color+)
-    ((string= (car cell) +cell-type-path+) +path-color+)
-    ((string= (car cell) +cell-type-wall+) +wall-color+)
     ((string= (car cell) +cell-type-entrance+) +entrance-color+)
     ((string= (car cell) +cell-type-exit+) +exit-color+)
+    ((string= (cadddr cell) t) +visited-color+)
+    ((string= (car cell) +cell-type-path+) +path-color+)
+    ((string= (car cell) +cell-type-wall+) +wall-color+)
     (t +path-color+)))
 
 ;; Definition: Returns a new cell changing the type of the given

--- a/src/maze/maze.lsp
+++ b/src/maze/maze.lsp
@@ -38,14 +38,17 @@
 ;;   - new-row: Row of the current/active cell
 ;;   - new-col: Column of the current/active cell
 ;; Out: A new maze object with the current cell updated
-(defun set-current (maze new-row new-col)
+(defun set-current (maze new-row new-col &optional visit)
   (let* ((grid (get-grid maze))
          (old-row (get-current-row maze))
          (old-col (get-current-col maze))
          
          ;; Get and update the old current cell (set current to NIL)
          (old-cell (get-cell grid old-row old-col))
-         (updated-old-cell (change-cell-current old-cell nil))
+         (visited-old-cell (cond
+                              (visit (visit old-cell))
+                              (t old-cell)))
+         (updated-old-cell (change-cell-current visited-old-cell nil))
          (grid-with-old-cleared (replace-in-grid grid old-row old-col updated-old-cell))
          
          ;; Get and update the new current cell (set current to T)
@@ -290,7 +293,7 @@
   (setq steps (+ steps 1))  ; Even if you can't move, step increases. Don't crash with walls!
   (cond
     ((string= (car (safe-get-cell (get-grid maze) new-row new-col)) +cell-type-wall+) maze)
-    (t (set-current maze new-row new-col))))
+    (t (set-current maze new-row new-col t))))
 
 ;; Definition: Moves the player up if it's posible
 ;; In:


### PR DESCRIPTION
This pull request introduces changes to enhance the maze traversal logic and improve cell state handling by adding a "visited" state for cells. The modifications include defining a new color constant for visited cells, updating cell color determination logic, and extending the maze's `set-current` function to optionally mark cells as visited.

### Enhancements to cell state and visualization:

* [`src/const/constants.lsp`](diffhunk://#diff-3de41924931b23d1c4f7747d9ce5be7df851fbe3d9111a65e56fa8a6972ce8f9R37): Added a new constant `+visited-color+` to represent the color of visited cells.
* [`src/core/cell.lsp`](diffhunk://#diff-76c9eade5bdec3a81bb1f52b07296e9583220eb8fc4aff9287623f6b5f4b7bb5L36-R40): Updated the `get-cell-color` function to include logic for determining the color of visited cells based on the new `+visited-color+` constant.

### Updates to maze traversal logic:

* [`src/maze/maze.lsp`](diffhunk://#diff-744510616bb711e998bf88e6e49aae8b7473e4e1e952720b0f3012a9ef2fd05bL41-R51): Modified the `set-current` function to accept an optional `visit` parameter. This allows marking the previous cell as visited when moving to a new cell.
* [`src/maze/maze.lsp`](diffhunk://#diff-744510616bb711e998bf88e6e49aae8b7473e4e1e952720b0f3012a9ef2fd05bL293-R296): Updated the movement logic to pass the `visit` parameter to `set-current`, ensuring cells are marked as visited during traversal.